### PR TITLE
fixing the title of a paper in the references

### DIFF
--- a/explainer.html
+++ b/explainer.html
@@ -42,7 +42,7 @@ var respecConfig = {
       rawDate : "2003"
     },
     "kasten-et-al-2014": {
-      title: "Canonical Forms for Isomorphic and Equivalent RDF Graphs: Algorithms for Leaning and Labelling Blank Nodes",
+      title: "A Framework for Iterative Signing of Graph Data on the Web",
       authors: [
         "Andreas Kasten",
         "Ansgar Scherp",


### PR DESCRIPTION
The reference to "A Framework for Iterative Signing of Graph Data on the Web" used a duplicate title copied from another entry.